### PR TITLE
[HOTFIX] 오픈웨더 2.5 -> 3.0 마이그레이션

### DIFF
--- a/src/main/java/com/server/tourApiProject/weather/observationalFit/ObservationalFitService.java
+++ b/src/main/java/com/server/tourApiProject/weather/observationalFit/ObservationalFitService.java
@@ -41,8 +41,8 @@ public class ObservationalFitService {
     private final DescriptionRepository descriptionRepository;
     private final WebClient webClient;
 
-    private static final String OPEN_WEATHER_URL = "https://api.openweathermap.org/data/2.5/onecall";
-    private static final String OPEN_WEATHER_API_KEY = "7c7ba4d9df15258ce566f6592d875413";
+    private static final String OPEN_WEATHER_URL = "https://api.openweathermap.org/data/3.0/onecall";
+    private static final String OPEN_WEATHER_API_KEY = "0c029f24189a0c735381c284d3fa54a0";
     private static final String OPEN_WEATHER_EXCLUDE = "current,minutely,alerts";
     private static final String OPEN_WEATHER_UNITS = "metric";
     private static final String OPEN_WEATHER_LANG = "kr";


### PR DESCRIPTION
- api url, api key 변경

## 이 PR의 목적
오픈웨더 2.5 deprecated 로 인한 마이그레이션

## 개발사항
api url, api key 변경

## 변경된 부분
api url, api key 변경

## 알려줄 내용
https://openweathermap.org/one-call-transfer#comparison 참고
