### PR TITLE
[FIX]메인 리뷰 페이지의 특수문자및 한글 포함 이미지 encoding 코드 추가

### DIFF
--- a/src/main/java/com/server/tourApiProject/bigPost/post/PostController.java
+++ b/src/main/java/com/server/tourApiProject/bigPost/post/PostController.java
@@ -5,15 +5,14 @@ import com.server.tourApiProject.bigPost.postHashTag.PostHashTagService;
 import com.server.tourApiProject.bigPost.postImage.PostImage;
 import com.server.tourApiProject.bigPost.postImage.PostImageService;
 import com.server.tourApiProject.observation.Observation;
-import com.server.tourApiProject.observation.ObservationService;
 import com.server.tourApiProject.observation.ObservationServiceImpl;
-import com.server.tourApiProject.search.Filter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @Slf4j
@@ -102,7 +101,7 @@ public class PostController {
 
     @ApiOperation(value = "메인페이지 게시물 정보 조회", notes = "메인페이지에 띄울 모든 게시물을 조회한다")
     @PostMapping(value = "post/main")
-    public List<PostParams4> getMainPost(){ return postService.getMainPost(); }
+    public List<PostParams4> getMainPost() throws UnsupportedEncodingException { return postService.getMainPost(); }
 
     @ApiOperation(value = "게시물 정보 사이즈로 조회", notes = "게시물 정보를 최신순으로 사이즈만큼 가져온다.")
     @GetMapping(value = "posts/{size}")

--- a/src/main/java/com/server/tourApiProject/bigPost/post/PostService.java
+++ b/src/main/java/com/server/tourApiProject/bigPost/post/PostService.java
@@ -17,6 +17,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -234,7 +236,7 @@ public class PostService {
      *
      * @return the list
      */
-    public List<PostParams4>getMainPost() {
+    public List<PostParams4>getMainPost() throws UnsupportedEncodingException {
         // 유저의 희망 해시태그에 따라 우선적 필터로 거르고 가져옴)
         List<PostParams4> result = new ArrayList<>();
         List<Post> posts = postRepository.findAll(Sort.by(Sort.Order.desc("postId")));
@@ -255,7 +257,8 @@ public class PostService {
                 if (!mainImageList.isEmpty()) {
                     ArrayList<String> imageList = new ArrayList<>();
                     for (int i = 0; i < mainImageList.size(); i++) {
-                        imageList.add("https://starry-night.s3.ap-northeast-2.amazonaws.com/postImage/" + mainImageList.get(i).getImageName());
+                        String image = URLEncoder.encode(mainImageList.get(i).getImageName(),"UTF-8");
+                        imageList.add("https://starry-night.s3.ap-northeast-2.amazonaws.com/postImage/" + image);
                     }
                     postParams4.setImages(imageList);
                 } else {


### PR DESCRIPTION
## 이 PR의 목적
리뷰 이미지에 특수문자, 한글 등이 포함되어 있을 때 encoding 시 이미지 경로를 잘 못 읽는 예외가 존재

## 개발사항
URLEncoder.encode() 코드를 통해 이 문제를 해결
## 변경된 부분

## 알려줄 내용

